### PR TITLE
added support of all compression methods to pve-verify-backups script

### DIFF
--- a/pve-verify-backups
+++ b/pve-verify-backups
@@ -5,7 +5,7 @@ DIR=`pwd`
 
 echo $DIR...
 
-for i in $DIR/*.vcdiff.lzo
+for i in $DIR/*.vcdiff.zst $DIR/*.vcdiff.lzo $DIR/*.vcdiff.gz $DIR/*.vcdiff
 do
         FILE=`basename $i`
         BASEFILE=${FILE//--differential-*/}


### PR DESCRIPTION
In the script for the checking integrity of differential backups, only one compression algorithm was initially supported - LZO.

If other compression algorithms will be used or are not used at all, the script simply did not saw the diff files.

Fixed.